### PR TITLE
use utf-8 times symbol instead of 'x'  to dismiss error messages

### DIFF
--- a/lib/devise_bootstrap_views_helper.rb
+++ b/lib/devise_bootstrap_views_helper.rb
@@ -9,7 +9,7 @@ module DeviseBootstrapViewsHelper
 
     html = <<-HTML
     <div class="alert alert-danger alert-block">
-      <button type="button" class="close" data-dismiss="alert">x</button>
+      <button type="button" class="close" data-dismiss="alert">⨉</button>
       <h5>#{sentence}</h4>
       #{messages}
     </div>


### PR DESCRIPTION
The ⨉ symbol is aesthetically more pleasing than a standalone x. Also, its used in the Bootstrap examples to close modals: http://getbootstrap.com/javascript/#modals-examples
