### PR TITLE
Update devise_bootstrap_views_helper.rb

### DIFF
--- a/lib/devise_bootstrap_views_helper.rb
+++ b/lib/devise_bootstrap_views_helper.rb
@@ -1,3 +1,5 @@
+# -*- encoding : utf-8 -*-
+
 module DeviseBootstrapViewsHelper
   def bootstrap_devise_error_messages!
     return '' if resource.errors.empty?


### PR DESCRIPTION
Hello,

The UTF8 "x" is not working in my case, on Ruby 1.9.3.

I added the encoding comment to make it work in my case.
