### PR TITLE
Fix remember_me check box in new session file

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,12 +14,11 @@
       </div>
       <% if devise_mapping.rememberable? %>
         <div class="checkbox">
-          <label>
-            <%= f.check_box :remember_me %>
-            <%= f.label :remember_me %>
-          </label>
+          <%= f.label :remember_me do %>
+            <%= f.check_box :remember_me %>remember me
+          <% end %>
         </div>
-        <% end %>
+      <% end %>
       <%= f.submit  t('.sign_in', :default => "Sign in"), class: "btn btn-primary" %>
     <% end %>
   </div>


### PR DESCRIPTION
The current views in log in page and in remember me section there is a gap between the check box itself and the `remember me` text (which you can see from the [screenshot](https://github.com/hisea/devise-bootstrap-views#screenshot) in the `README.md` file). To compare the difference check out the Bootstrap example [forms-horizontal](http://getbootstrap.com/css/#forms-horizontal) .
