### PR TITLE
Missing pt translation fix

### DIFF
--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -99,7 +99,7 @@ pt:
         didn_t_receive_confirmation_instructions: Não recebeu instruções de confirmação?
         didn_t_receive_unlock_instructions: Não recebeu instruções de desbloqueio?
         forgot_your_password: Equeceu a palavra-passe?
-        sign_in: Login
+        sign_in: Entrar
         sign_in_with_provider: Entrar com %{provider}
         sign_up: Criar conta
     unlocks:


### PR DESCRIPTION
"Entrar" is the proper portuguese word for this purpose instead of "Login", and is already used on line 93 already, so this adds consistency to it.