### PR TITLE
Update Slovenian locale.

### DIFF
--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -2,20 +2,20 @@ sl:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password: Trenutno geslo
+        email: E-pošta
+        password: Geslo
+        password_confirmation: Potrditev gesla
+        remember_me: Zapomni si me
+        reset_password_token: Znak za ponastavitev gesla
+        unlock_token: Znak za odklep
     models:
-      user: 
+      user: Uporabnik
   devise:
     confirmations:
       confirmed: Vaš račun je bil uspešno potrjen. Sedaj ste prijavljeni.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions: Ponovno pošlji navodila za potrditev
       send_instructions: Prejeli boste e-pošto z navodili kako potrditi vaš račun.
       send_paranoid_instructions: "Če vaša e-pošta obstaja v naši bazi, boste v naslednjih minutah prejeli e-pošto z navodili kako potrditi vaš uporabniški račun."
     failure:
@@ -30,39 +30,45 @@ sl:
       unconfirmed: Pred nadaljevanjem morate potrditi vaš račun.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action: Potrdi moj račun
+        greeting: 'Dobrodošli, %{recipient}!'
+        instruction: 'E-pošto uporabniškega računa lahko potrdite s spodnjo povezavo:'
         subject: Navodila potrditve
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting: 'Pozdravljeni, %{recipient}!'
+        message: 'Obveščamo vas, da je bilo vaše geslo spremenjeno.'
+        subject: Geslo spremenjeno
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action: Spremeni geslo
+        greeting: 'Pozdravljeni %{recipient}!'
+        instruction: >-
+          Nekdo je zahteval povezavo za spremembo gesla. To lahko storite s
+          sledečo povezavo.
+        instruction_2: 'Če tega niste zahtevali, vas prosimo, da ignorirate to sporočilo.'
+        instruction_3: >-
+          Vaše geslo se ne bo spremenilo dokler ne pristopite k zgornji povezavi
+          in ustvarite novega.
         subject: Navodila za ponastavitev gesla
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action: Odkleni moj račun
+        greeting: 'Pozdravljeni %{recipient}!'
+        instruction: 'Pritisnite na spodnjo povezavo, da odklenete vaš račun:'
+        message: >-
+          Vaš račun je bil zaklenjen zaradi prekomernega števila neuspešnih
+          poskusov vpisa.
         subject: Navodila odklepa
     omniauth_callbacks:
       failure: Preverjanje pristnosti ni uspelo iz %{kind} zaradi "%{reason}".
       success: Uspešno preverjena pristnost iz računa %{kind}.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password: Spremeni geslo
+        change_your_password: Spremenite vaše geslo
+        confirm_new_password: Potrdite novo geslo
+        new_password: Novo geslo
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password: Pozabili geslo?
+        send_me_reset_password_instructions: Pošljite mi navodila za ponastavitev  gesla
       no_token: Do te strani lahko dostopate samo iz povezave v e-pošti za ponastavitev gesla. Če pa ste prišli do te strani preko omenjene povezave, preverite, da ste uporabili celotni URL.
       send_instructions: V naslednjih minutah boste prejeli e-pošto z navodili kako ponastaviti vaše geslo.
       send_paranoid_instructions: "Če vaša e-pošta obstaja v bazi, boste v naslednjih minutah na vašo e-pošto prejeli povezavo za obnovitev gesla."
@@ -71,16 +77,16 @@ sl:
     registrations:
       destroyed: Nasvidenje. Vaš račun je bil uspešno preklican. Upamo, da se kmalu vrnete.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure: Ali ste prepričani?
+        cancel_my_account: Preklic mojega računa
+        currently_waiting_confirmation_for_email: 'Trenutno se čaka na potrditev za: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: 'pustite prazno, če ne želite opraviti sprememb'
+        title: 'Uredi %{resource}'
+        unhappy: Nesrečen
+        update: Posodobitev
+        we_need_your_current_password_to_confirm_your_changes: 'potrebujemo vaše trenutno geslo, da potrdimo spremembe'
       new:
-        sign_up: 
+        sign_up: Prijava
       signed_up: Dobrodošli. Uspešno ste se registrirali.
       signed_up_but_inactive: Uspešno ste se registrirali, vendar pred prvo prijavo je potrebno vaš račun še aktivirati.
       signed_up_but_locked: Uspešno ste se registrirali, vendar prijava ni mogoča, ker je vaš račun zaklenjen.
@@ -88,23 +94,23 @@ sl:
       update_needs_confirmation: Vaš račun je uspešno posodobljen, vendar potrebno je preveriti vaš novi e-poštni naslov. Prosimo, preverite vašo e-pošto in kliknite na potrditveno povezavo za dokončanje potrditve vašega novega e-poštnega naslova.
       updated: Uspešno ste posodobili vaš račun.
     sessions:
-      already_signed_out: 
+      already_signed_out: Odjava je bila uspešna.
       new:
-        sign_in: 
+        sign_in: Vpis
       signed_in: Prijava je bila uspešna.
       signed_out: Odjava je bila uspešna.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back: Nazaj
+        didn_t_receive_confirmation_instructions: Niste prejeli potrditvenih navodil?
+        didn_t_receive_unlock_instructions: Niste prejeli navodil za odklep?
+        forgot_your_password: Pozabljeno geslo?
+        sign_in: Vpis
+        sign_in_with_provider: 'Vpis z %{provider}'
+        sign_up: Prijava
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions: Ponovno pošlji navodila za odklep
       send_instructions: V naslednjih minutah boste prejeli e-pošto z navodili, kako odkleniti vaš račun.
       send_paranoid_instructions: "Če vaš račun obstaja, boste v naslednjih minutah prejeli e-pošto z navodili kako odkleniti vaš račun."
       unlocked: Vaš račun je bil uspešno odklenjen. Prosimo, prijavite se za nadaljevanje.


### PR DESCRIPTION
By Jernej Omulec.

When adding the Slovenian translation to our website (see thewca/worldcubeassociation.org#1321) we noticed the locale file for this language here was missing a lot of stuff.
We asked our Slovenian translator to complete the locale file from this repo and here is his work :)

Since most of our translators are not developers nor IT guys, we developed [an app](http://internationalize.herokuapp.com/) to translate a locale file based on an original one; Jernej used it to create this file, based on the English one.
It enforces interpolation variables, so even if I did not test the translation locally, I'm confident it is correct.