### PR TITLE
Fixed error for Net:HTTP not being explicitly required

### DIFF
--- a/lib/generators/devise/views/locale/locale_generator.rb
+++ b/lib/generators/devise/views/locale/locale_generator.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module Devise
   module Views
     class LocaleGenerator < Rails::Generators::NamedBase


### PR DESCRIPTION
Checking issue: #52 I believe the problem is that 'net/http' was not explicitly required, so I added the required. I tested the code on my fork and used it in a test app I'm playing with, it worked without a problem. 

Let me know if this is ok.