### PR TITLE
Fix: "remember me" not translated.

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,7 +15,7 @@
     <div class="form-check">
       <%= f.label :remember_me, class: 'form-check-label' do %>
         <%= f.check_box :remember_me, class: 'form-check-input' %>
-        <%= t('.remember_me', default: 'Remember me') %>
+        <%= t('activerecord.attributes.user.remember_me', default: 'Remember me') %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
The "remember me" string is not translated in the new session form.